### PR TITLE
Added ability to toggle backquotes

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,16 +1,23 @@
 [
-    { "keys": ["'"], "command": "toggle_quotes", "context":
+    { "keys": ["'"], "command": "toggle_quotes", "args": { "key": "'" }, "context":
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "text", "operator" : "regex_contains", "operand": "^\".*\"$", "match_all": true}
+            { "key": "text", "operator" : "regex_contains", "operand": "^\".*\"|`.*`$", "match_all": true}
         ]
     },
-    { "keys": ["\""], "command": "toggle_quotes", "context":
+    { "keys": ["\""], "command": "toggle_quotes", "args": { "key": "\"" }, "context":
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "text", "operator" : "regex_contains", "operand": "^'.*'$", "match_all": true}
+            { "key": "text", "operator" : "regex_contains", "operand": "^'.*'|`.*`$", "match_all": true}
+        ]
+    },
+    { "keys": ["`"], "command": "toggle_quotes", "args": { "key": "`" }, "context":
+        [
+            { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "text", "operator" : "regex_contains", "operand": "^\".*\"|'.*'$", "match_all": true}
         ]
     },
     { "keys": ["ctrl+'"], "command": "toggle_quotes", "context":

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -3,21 +3,21 @@
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "text", "operator" : "regex_contains", "operand": "^\".*\"|`.*`$", "match_all": true}
+            { "key": "text", "operator" : "regex_contains", "operand": "^(\".*\"|`.*`)$", "match_all": true}
         ]
     },
     { "keys": ["\""], "command": "toggle_quotes", "args": { "key": "\"" }, "context":
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "text", "operator" : "regex_contains", "operand": "^'.*'|`.*`$", "match_all": true}
+            { "key": "text", "operator" : "regex_contains", "operand": "^('.*'|`.*`)$", "match_all": true}
         ]
     },
     { "keys": ["`"], "command": "toggle_quotes", "args": { "key": "`" }, "context":
         [
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "text", "operator" : "regex_contains", "operand": "^\".*\"|'.*'$", "match_all": true}
+            { "key": "text", "operator" : "regex_contains", "operand": "^(\".*\"|'.*')$", "match_all": true}
         ]
     },
     { "keys": ["ctrl+'"], "command": "toggle_quotes", "context":

--- a/toggle_quotes.py
+++ b/toggle_quotes.py
@@ -2,11 +2,11 @@ import sublime_plugin
 import re
 from sublime import Region
 
-re_quotes = re.compile("^(['\"])(.*)\\1$")
+re_quotes = re.compile("^(['\"`])(.*)\\1$")
 
 
 class ToggleQuotesCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
+    def run(self, edit, **kwargs):
         v = self.view
         if v.sel()[0].size() == 0:
             v.run_command("expand_selection", {"to": "scope"})
@@ -24,7 +24,7 @@ class ToggleQuotesCommand(sublime_plugin.TextCommand):
                     #  still no match... skip it!
                     continue
             oldQuotes = res.group(1)
-            newQuotes = "'" if oldQuotes == '"' else '"'
+            newQuotes = kwargs["key"]
             text = res.group(2)
             text = text.replace(newQuotes, "\\" + newQuotes)
             text = text.replace("\\" + oldQuotes, oldQuotes)
@@ -39,3 +39,4 @@ class ToggleQuotesCommand(sublime_plugin.TextCommand):
 # 'te"st'
 # "te\"st"
 # "te'st"
+# `te"s't`


### PR DESCRIPTION
I really like this plugin, and am using it with JavaScript ES6 which features string templating with backquotes/backticks `` ` ``.

I thought I would try to include it in this plugin, and close Issue #12. Behaviour is what you'd expect: select quoted text and press the `` ` `` key to swap quotes.

Thanks