### PR TITLE
Fixed ctrl+' shortcut to toggle between the three types of quotes

### DIFF
--- a/toggle_quotes.py
+++ b/toggle_quotes.py
@@ -3,13 +3,14 @@ import re
 from sublime import Region
 
 re_quotes = re.compile("^(['\"`])(.*)\\1$")
+quoteList = ['\'', '"', '`']
 
 
 class ToggleQuotesCommand(sublime_plugin.TextCommand):
     def run(self, edit, **kwargs):
         v = self.view
         if v.sel()[0].size() == 0:
-            v.run_command("expand_selection", {"to": "scope"})
+            v.run_command('expand_selection', {'to': 'scope'})
 
         for sel in v.sel():
             text = v.substr(sel)
@@ -24,7 +25,10 @@ class ToggleQuotesCommand(sublime_plugin.TextCommand):
                     #  still no match... skip it!
                     continue
             oldQuotes = res.group(1)
-            newQuotes = kwargs["key"]
+            if 'key' in kwargs:
+                newQuotes = kwargs['key']
+            else:
+                newQuotes = quoteList[(quoteList.index(oldQuotes) + 1) % len(quoteList)]
             text = res.group(2)
             text = text.replace(newQuotes, "\\" + newQuotes)
             text = text.replace("\\" + oldQuotes, oldQuotes)


### PR DESCRIPTION
This will make the <kbd>ctrl</kbd>+<kbd>'</kbd> shortcut work with the new backquote addition.

The shortcut will now cycle between `` ' " ` ``, in that order, depending on which quote style the string was already using.